### PR TITLE
sepolicy-legacy-um: Remove duplicate Bluetooth device define

### DIFF
--- a/legacy/vendor/common/device.te
+++ b/legacy/vendor/common/device.te
@@ -162,9 +162,6 @@ type avtimer_device, dev_type;
 #define AT device
 type at_device, dev_type;
 
-#define Bluetooth device
-type bt_device, dev_type;
-
 #define Wlan device
 type wlan_device, dev_type;
 


### PR DESCRIPTION
* Move to https://github.com/Miku-UI/platform_system_sepolicy/blob/a77775a85242c5fa9ee5a04c8d49a2dfebf830d0/prebuilts/api/34.0/public/device.te#L10

Change-Id: I5bf5b9bbd9cbf694435df1dde18068a62b69138b