### PR TITLE
legacy: allow apexd to write to sysfs_mmc_host

### DIFF
--- a/legacy/vendor/common/apexd.te
+++ b/legacy/vendor/common/apexd.te
@@ -1,0 +1,2 @@
+# Allow apexd to configure read_ahead_kb
+allow apexd sysfs_mmc_host:file rw_file_perms;


### PR DESCRIPTION
As qualcomm relabels read_ahead_kb and friends as sysfs_mmc_host we explicitly need to grant apexd access to it or it will break.

This results in eg GSIs to be unbootable.

type=1400 audit(3799551.036:40): avc: denied { read write }
  for comm="apexd" name="read_ahead_kb" dev="sysfs" ino=81305
  scontext=u:r:apexd:s0 tcontext=u:object_r:sysfs_mmc_host:s0
  tclass=file permissive=0

Change-Id: Iea24b94318893e8526e06e24bc3308acba37b0cc